### PR TITLE
import terraform vis resource

### DIFF
--- a/examples/import/.terraform.lock.hcl
+++ b/examples/import/.terraform.lock.hcl
@@ -1,0 +1,10 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "faze.com/gallery/faze-gallery" {
+  version     = "0.1.0"
+  constraints = "0.1.0"
+  hashes = [
+    "h1:rprWghSvzqWzeKYbSRGpqFfdQypv0714CFd3Tx5W1fc=",
+  ]
+}

--- a/examples/import/main.tf
+++ b/examples/import/main.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    fazegallery = {
+      version = "0.1"
+      source  = "faze.com/gallery/faze-gallery"
+    }
+  }
+}
+
+resource "fazegallery_visualisation" "sample" {}
+
+output "sample_vis" {
+  value = fazegallery_visualisation.sample
+}
+

--- a/fazegallery/resource_visualisation.go
+++ b/fazegallery/resource_visualisation.go
@@ -28,6 +28,9 @@ func resourceVisualisation() *schema.Resource {
 				Required: true,
 			},
 		},
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 	}
 }
 


### PR DESCRIPTION
Following from the tutorial [here](https://learn.hashicorp.com/tutorials/terraform/provider-import?in=terraform/providers)
```
G:\Source\Repos\terraform-provider-faze-gallery\examples\import>terraform import fazegallery_visualisation.sample someid1
fazegallery_visualisation.sample: Importing from ID "someid1"...
fazegallery_visualisation.sample: Import prepared!
  Prepared fazegallery_visualisation for import
fazegallery_visualisation.sample: Refreshing state... [id=someid1]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.


G:\Source\Repos\terraform-provider-faze-gallery\examples\import>terraform state show fazegallery_visualisation.sample
# fazegallery_visualisation.sample:
resource "fazegallery_visualisation" "sample" {
    id   = "someid1"
    name = "Visualisation name 1"
}
```